### PR TITLE
Bugfix: Broken Volumio with no internet.

### DIFF
--- a/index.js
+++ b/index.js
@@ -916,7 +916,7 @@ ControllerLastFM.prototype.formatScrobbleData = function (state)
 ControllerLastFM.prototype.initLastFMSession = function () {
     var self = this;
 	var defer = libQ.defer();
-    
+    var url = 'ws.audioscrobbler.com';
     var msg = '';
     
     if (
@@ -929,30 +929,36 @@ ControllerLastFM.prototype.initLastFMSession = function () {
         if (debugEnabled)
             self.logger.info('[LastFM] trying to authenticate...');
 
-        self.lfm = new lastfm({
-            api_key: self.config.get('API_KEY'),
-            api_secret: self.config.get('API_SECRET'),
-            username: self.config.get('username'),
-            authToken: self.config.get('authToken')
-        });
-
-        self.lfm.getSessionKey(function (result)
-		{
-            if (result.success)
-			{
-                self.commandRouter.pushToastMessage('success', 'LastFM connection', 'Authenticated successfully with LastFM.');
-                if (debugEnabled)
-                    self.logger.info('[LastFM] authenticated successfully!');
-                defer.resolve('Authenticated successfully!');
-            }
-            else
-			{
-                msg = 'Error: ' + result.error;
-                self.commandRouter.pushToastMessage('error', 'LastFM connection failed', msg);                    
-                self.logger.error('[LastFM] ' + msg); 
-                defer.reject(msg);
-            }
-        });
+		self.checkURL(url)
+			.then(function() {	
+				self.lfm = new lastfm({
+					api_key: self.config.get('API_KEY'),
+					api_secret: self.config.get('API_SECRET'),
+					username: self.config.get('username'),
+					authToken: self.config.get('authToken')
+				});
+		
+				self.lfm.getSessionKey(function (result)
+				{
+					if (result.success)
+					{
+						self.commandRouter.pushToastMessage('success', 'LastFM connection', 'Authenticated successfully with LastFM.');
+						if (debugEnabled)
+							self.logger.info('[LastFM] authenticated successfully!');
+						defer.resolve('Authenticated successfully!');
+					}
+					else
+					{
+						msg = 'Error: ' + result.error;
+						self.commandRouter.pushToastMessage('error', 'LastFM connection failed', msg);                    
+						self.logger.error('[LastFM] ' + msg); 
+						defer.reject(msg);
+					}
+				});
+			})
+			.catch(function() {
+				defer.reject(false);
+			});
     }
     else
 	{


### PR DESCRIPTION
When there's no Internet connection, Volumio can't initialize correctly and enters a restarting loop.
The error is fired by the simple-lastfm dependency on auth.

I just added a URL validation before starting the simple-lastfm auth process using the existing checkURL method available in the plugin.

I've done this as a quick simple fix in my running Volumio instance. Sorry I didn't get the logs or screenshots, but it's the same issue on https://github.com/Saiyato/volumio-lastfm-plugin/issues/11.